### PR TITLE
FIX DE BUG IMPORTANTE(leer descrip) + arreglo de MenuServiceTest y to…

### DIFF
--- a/src/main/java/org/springframework/samples/aerolineasAAAFC/model/Aeropuerto.java
+++ b/src/main/java/org/springframework/samples/aerolineasAAAFC/model/Aeropuerto.java
@@ -45,9 +45,11 @@ public class Aeropuerto extends BaseEntity{
 	// Relaciones de tabla:
 	
 	@OneToMany(cascade = CascadeType.ALL, mappedBy="aeropuertoOrigen")
+	@EqualsAndHashCode.Exclude
 	private Set<Vuelo> vuelosSalida;
 
 	@OneToMany(cascade = CascadeType.ALL, mappedBy="aeropuertoDestino")
+	@EqualsAndHashCode.Exclude
 	private Set<Vuelo> vuelosLlegada;
 	
 

--- a/src/main/java/org/springframework/samples/aerolineasAAAFC/model/Authorities.java
+++ b/src/main/java/org/springframework/samples/aerolineasAAAFC/model/Authorities.java
@@ -17,6 +17,7 @@ public class Authorities extends BaseEntity{
 	
 	@ManyToOne
 	@JoinColumn(name = "username")
+	@EqualsAndHashCode.Exclude
 	User user;
 	
 	@Size(min = 3, max = 50)

--- a/src/main/java/org/springframework/samples/aerolineasAAAFC/model/Avion.java
+++ b/src/main/java/org/springframework/samples/aerolineasAAAFC/model/Avion.java
@@ -72,9 +72,11 @@ public class Avion extends BaseEntity{
 	private Set<Vuelo> vuelos;
 	
 	@ManyToMany(mappedBy="aviones")
+	@EqualsAndHashCode.Exclude
 	private Set<Azafato> azafatos;
 	
 	@ManyToMany(mappedBy="aviones")
+	@EqualsAndHashCode.Exclude
 	private Set<PersonalControl> personalControl;
 	
 }

--- a/src/main/java/org/springframework/samples/aerolineasAAAFC/model/Azafato.java
+++ b/src/main/java/org/springframework/samples/aerolineasAAAFC/model/Azafato.java
@@ -53,6 +53,7 @@ public class Azafato extends BaseEntity{
 	@JoinTable(name = "idiomas_azafato", 
 	joinColumns = @JoinColumn(name = "azafato_id"),
 	inverseJoinColumns = @JoinColumn(name = "idioma_id"))
+	@EqualsAndHashCode.Exclude 
 	private Set<Idioma> idiomas;
 
 	@Column(name = "salario")
@@ -62,10 +63,12 @@ public class Azafato extends BaseEntity{
 	// Relaciones de tabla:
 
 	@ManyToMany(cascade = CascadeType.ALL)
+	@EqualsAndHashCode.Exclude 
 	private Set<Avion> aviones;
 
 	@OneToOne(cascade = CascadeType.ALL)
 	@JoinColumn(name = "username", referencedColumnName = "username")
+	@EqualsAndHashCode.Exclude 
 	private User user;
 
 }

--- a/src/main/java/org/springframework/samples/aerolineasAAAFC/model/Billete.java
+++ b/src/main/java/org/springframework/samples/aerolineasAAAFC/model/Billete.java
@@ -1,4 +1,4 @@
-	package org.springframework.samples.aerolineasAAAFC.model;
+package org.springframework.samples.aerolineasAAAFC.model;
 
 import java.time.LocalDate;
 import java.util.Set;
@@ -18,13 +18,12 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 
 import org.springframework.format.annotation.DateTimeFormat;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 
 @Data
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper=true)
 @Entity
 @Table(name = "billetes")
 public class Billete extends BaseEntity{
@@ -54,9 +53,11 @@ public class Billete extends BaseEntity{
 	// Relaciones de tabla:
 
 	@OneToMany(cascade = CascadeType.ALL, mappedBy = "billete")
+	@EqualsAndHashCode.Exclude
 	private Set<Equipaje> equipajes;
 	
 	@OneToMany(cascade = CascadeType.ALL, mappedBy = "billete")
+	@EqualsAndHashCode.Exclude 
 	private Set<Menu> menus;
 	
 	@ManyToOne(optional=true) //segun el model un billete no tiene por qué ir asociado a un cliente
@@ -65,4 +66,9 @@ public class Billete extends BaseEntity{
 	
 	@ManyToMany(cascade = CascadeType.ALL)
 	private Set<Vuelo> vuelos;
+	
+	public String toString() {
+		
+		return this.getId()+" "+this.getAsiento()+" "+this.getMenus()+" "+this.getEquipajes();
+	}
 }

--- a/src/main/java/org/springframework/samples/aerolineasAAAFC/model/Cliente.java
+++ b/src/main/java/org/springframework/samples/aerolineasAAAFC/model/Cliente.java
@@ -60,10 +60,12 @@ public class Cliente extends BaseEntity{
 
 
 	@OneToMany(cascade = CascadeType.ALL, mappedBy="cliente") //fetch = FetchType.EAGER 
+	@EqualsAndHashCode.Exclude
 	private Set<Billete> billetes;
 	
 	@OneToOne(cascade = CascadeType.ALL)
     @JoinColumn(name = "username", referencedColumnName = "username")
+	@EqualsAndHashCode.Exclude
 	private User user;
 	
 }

--- a/src/main/java/org/springframework/samples/aerolineasAAAFC/model/Equipaje.java
+++ b/src/main/java/org/springframework/samples/aerolineasAAAFC/model/Equipaje.java
@@ -38,6 +38,7 @@ public class Equipaje extends BaseEntity{
 	
 	@ManyToOne(optional=false)
 	@JoinColumn(name = "billete_id")
+	@EqualsAndHashCode.Exclude
 	private Billete billete;
 	
 }

--- a/src/main/java/org/springframework/samples/aerolineasAAAFC/model/Idioma.java
+++ b/src/main/java/org/springframework/samples/aerolineasAAAFC/model/Idioma.java
@@ -1,7 +1,11 @@
 package org.springframework.samples.aerolineasAAAFC.model;
 
+import java.util.Set;
+
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.ManyToMany;
 import javax.persistence.Table;
 import javax.validation.constraints.NotEmpty;
 
@@ -17,4 +21,9 @@ public class Idioma extends BaseEntity{
 	@Column(name = "idioma")
 	@NotEmpty
 	private String idioma; 
+	
+	//Indicando que idiomas es de tipo Agregación (puede seguir habiendo idiomas sin X azafatos)
+	@ManyToMany(cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.DETACH, CascadeType.REFRESH})
+	@EqualsAndHashCode.Exclude 
+	private Set<Azafato> azafatos;
 }

--- a/src/main/java/org/springframework/samples/aerolineasAAAFC/model/Menu.java
+++ b/src/main/java/org/springframework/samples/aerolineasAAAFC/model/Menu.java
@@ -41,7 +41,13 @@ public class Menu extends BaseEntity {
 	
 	@ManyToOne(optional=false)
 	@JoinColumn(name = "billete_id")
+	@EqualsAndHashCode.Exclude 
 	private Billete billete;
+	
+	public String toString() {
+		
+		return "Id menú "+this.getId()+" Precio "+this.getPrecio()+" Id Billete "+(this.getBillete()==null?"":this.getBillete().getId());
+	}
 	
 
 }

--- a/src/main/java/org/springframework/samples/aerolineasAAAFC/model/PersonalControl.java
+++ b/src/main/java/org/springframework/samples/aerolineasAAAFC/model/PersonalControl.java
@@ -59,10 +59,12 @@ public class PersonalControl extends BaseEntity{
 	// Relaciones de tabla:
 	
 	@ManyToMany(cascade = CascadeType.ALL)
+	@EqualsAndHashCode.Exclude
 	private Set<Avion> aviones;
 	
 	@OneToOne(cascade = CascadeType.ALL)
     @JoinColumn(name = "username", referencedColumnName = "username")
+	@EqualsAndHashCode.Exclude
 	private User user;
 
 	

--- a/src/main/java/org/springframework/samples/aerolineasAAAFC/model/PersonalOficina.java
+++ b/src/main/java/org/springframework/samples/aerolineasAAAFC/model/PersonalOficina.java
@@ -54,10 +54,12 @@ public class PersonalOficina extends BaseEntity{
 	
 	@OneToOne(cascade = CascadeType.ALL)
     @JoinColumn(name = "username", referencedColumnName = "username")
+	@EqualsAndHashCode.Exclude
 	private User user;
 
 	// Relaciones de tabla:
 	
 	@ManyToMany(cascade = CascadeType.ALL)
+	@EqualsAndHashCode.Exclude
 	private Collection<Vuelo> vuelos;
 }

--- a/src/main/java/org/springframework/samples/aerolineasAAAFC/model/Vuelo.java
+++ b/src/main/java/org/springframework/samples/aerolineasAAAFC/model/Vuelo.java
@@ -51,21 +51,26 @@ public class Vuelo extends BaseEntity{
 	// Relaciones de tabla:
 
 	@ManyToMany(mappedBy = "vuelos")
+	@EqualsAndHashCode.Exclude
 	private Set<Billete> billetes;
 	
 	@ManyToMany(mappedBy = "vuelos")
+	@EqualsAndHashCode.Exclude
 	private Set<PersonalOficina> personalOficina;
 	
 	// Relacion con aeropuerto: ¿dos ManyToOne? o se hace algo diferente
 	@ManyToOne(optional=false)
 	@UniqueElements
+	@EqualsAndHashCode.Exclude
 	private Aeropuerto aeropuertoOrigen;
 	
 	@ManyToOne(optional=false)
 	@UniqueElements
+	@EqualsAndHashCode.Exclude
 	private Aeropuerto aeropuertoDestino;
 	
 	@ManyToMany(cascade = CascadeType.ALL)
+	@EqualsAndHashCode.Exclude
 	private Set<Avion> aviones;
 	
 	

--- a/src/test/java/org/springframework/samples/aerolineasAAAFC/service/MenuServiceTests.java
+++ b/src/test/java/org/springframework/samples/aerolineasAAAFC/service/MenuServiceTests.java
@@ -46,11 +46,11 @@ public class MenuServiceTests {
 		assertThat(billete1.getMenus().size()).isEqualTo(found + 1);
 		
 		menu.setBillete(billete1);
-		Logger.getLogger(MenuServiceTests.class.getName()).log(Level.INFO, "Existe billete con menús: "+billete1.getMenus().size());
+		Logger.getLogger(MenuServiceTests.class.getName()).log(Level.INFO, "Existe billete con menús: "+billete1.toString());
 		
 		try {
 			Logger.getLogger(MenuServiceTests.class.getName()).log(Level.INFO, "Introducimos el menú: "
-		+menu.getPostre()+" "+menu.getPrimerPlato()+" "+menu.getSegundoPlato());
+		+ menu.toString());
 			
 			menuService.saveMenu(menu);
 		} catch (MenuPriceException ex) {
@@ -59,6 +59,8 @@ public class MenuServiceTests {
 		}
 		
 		this.billeteService.saveBillete(billete1);
+		Logger.getLogger(MenuServiceTests.class.getName()).log(Level.INFO, "El menú tiene id: "
+				+ menu.getId());
 		assertThat(billete1.getMenus().size()).isEqualTo(found + 1);
 		// checks that id has been generated
 		assertThat(menu.getId()).isNotNull();


### PR DESCRIPTION
…Strings

Las etiquietas nuevas de cada modelo (@EqualsAndHashCode.Exclude) sirven para no generar "dependencias circulares". El no tenerlas podía generar un bucle de peticiones de hashCode entre las asociaciones entidad-entidad para determinados métodos.
Lo único que hacen es excluir del cálculo de hashCode y equals a los campos seleccionados.
En el caso de que de algún error de nuevo por esto, consultad: https://projectlombok.org/features/EqualsAndHashCode