### PR TITLE
Creación de tests para la clase Aeropuerto

### DIFF
--- a/src/main/java/org/springframework/samples/aerolineasAAAFC/model/Aeropuerto.java
+++ b/src/main/java/org/springframework/samples/aerolineasAAAFC/model/Aeropuerto.java
@@ -39,7 +39,7 @@ public class Aeropuerto extends BaseEntity{
 
 	@Column(name = "telefono")
 	@NotEmpty
-	@Pattern(regexp="^(\\+34|0034|34)?[6|7|9][0-9]{8}$")
+	@Pattern(regexp="^(\\+|\\d)[0-9]{7,16}$")
 	private String telefono;
 
 	// Relaciones de tabla:

--- a/src/main/java/org/springframework/samples/aerolineasAAAFC/service/AeropuertoService.java
+++ b/src/main/java/org/springframework/samples/aerolineasAAAFC/service/AeropuertoService.java
@@ -1,9 +1,14 @@
 package org.springframework.samples.aerolineasAAAFC.service;
 
+import java.util.Collection;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataAccessException;
 import org.springframework.samples.aerolineasAAAFC.model.Aeropuerto;
 import org.springframework.samples.aerolineasAAAFC.repository.AeropuertoRepository;
+import org.springframework.samples.aerolineasAAAFC.service.exceptions.TelefonoErroneoException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,8 +23,13 @@ public class AeropuertoService {
 	}	
 
 	@Transactional
-	public void saveAeropuerto(Aeropuerto aeropuerto) throws DataAccessException{
-		aeropuertoRepository.save(aeropuerto);
+	public void saveAeropuerto(Aeropuerto aeropuerto) throws DataAccessException, TelefonoErroneoException{
+		String aux = aeropuerto.getTelefono();
+		if(!(aux.matches("^(\\+|\\d)[0-9]{7,16}$"))) {
+			throw new TelefonoErroneoException();
+		} else {
+			aeropuertoRepository.save(aeropuerto);
+		}
 	}
 
 
@@ -27,7 +37,12 @@ public class AeropuertoService {
 	public Aeropuerto findAeropuertoById(int id) throws DataAccessException{
 		return aeropuertoRepository.findById(id).get();
 	}
-
+	
+	@Transactional
+	public Collection<Aeropuerto> findAeropuertos(){
+		return StreamSupport.stream(aeropuertoRepository.findAll().spliterator(), false)
+				.collect(Collectors.toList());
+	}
 
 	public void eliminarAeropuerto(int id) throws DataAccessException {
 		aeropuertoRepository.deleteById(id);

--- a/src/main/java/org/springframework/samples/aerolineasAAAFC/service/exceptions/TelefonoErroneoException.java
+++ b/src/main/java/org/springframework/samples/aerolineasAAAFC/service/exceptions/TelefonoErroneoException.java
@@ -1,0 +1,5 @@
+package org.springframework.samples.aerolineasAAAFC.service.exceptions;
+
+public class TelefonoErroneoException extends Exception{
+
+}

--- a/src/main/java/org/springframework/samples/aerolineasAAAFC/web/AeropuertoController.java
+++ b/src/main/java/org/springframework/samples/aerolineasAAAFC/web/AeropuertoController.java
@@ -7,6 +7,7 @@ import javax.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.samples.aerolineasAAAFC.model.Aeropuerto;
 import org.springframework.samples.aerolineasAAAFC.service.AeropuertoService;
+import org.springframework.samples.aerolineasAAAFC.service.exceptions.TelefonoErroneoException;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
@@ -18,7 +19,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 
 @Controller
 public class AeropuertoController {
-	private static final String VIEWS_AEROPUERTO_CREATE_OR_UPDATE_FORM = "aeropuerto/createOrUpdateAeropuertoForm";
+	private static final String VIEWS_AEROPUERTO_CREATE_OR_UPDATE_FORM = "aeropuertos/createOrUpdateAeropuertoForm";
 
 	private final AeropuertoService aeropuertoService;
 	
@@ -33,20 +34,25 @@ public class AeropuertoController {
 	}
 	
 	
-	@GetMapping(value = "/aeropuerto/new") 
+	@GetMapping(value = "/aeropuertos/new") 
 	public String initCreationAeropuertoForm(Map<String, Object> model) {
 		Aeropuerto aeropuerto = new Aeropuerto();
 		model.put("aeropuerto", aeropuerto);
 		return VIEWS_AEROPUERTO_CREATE_OR_UPDATE_FORM;
 	}
 	
-	@PostMapping(value = "/aeropuerto/new")
+	@PostMapping(value = "/aeropuertos/new")
 	public String processCreationVueloForm(@Valid Aeropuerto aeropuerto, BindingResult result) {
 		if(result.hasErrors()) {
 			return VIEWS_AEROPUERTO_CREATE_OR_UPDATE_FORM;
 		}
 		else {
-			this.aeropuertoService.saveAeropuerto(aeropuerto);
+			try {
+				this.aeropuertoService.saveAeropuerto(aeropuerto);
+			} catch (TelefonoErroneoException e) {
+				 result.rejectValue("telefono", "invalid", "invalid phone number");
+				 return VIEWS_AEROPUERTO_CREATE_OR_UPDATE_FORM;
+			}
 			
 			return "redirect:/aeropuertos/" + aeropuerto.getId();
 		}
@@ -54,7 +60,7 @@ public class AeropuertoController {
 	
 	//MODIFICACION
 	
-	@GetMapping(value = "/aeropuerto/{aeropuertoId}/edit")
+	@GetMapping(value = "/aeropuertos/{aeropuertoId}/edit")
 	public String initUpdateAeropuertoForm(@PathVariable("aeropuertoId") int aeropuertoId, Model model) {
 		Aeropuerto aeropuerto = this.aeropuertoService.findAeropuertoById(aeropuertoId);
 		model.addAttribute(aeropuerto);
@@ -62,20 +68,22 @@ public class AeropuertoController {
 	}
 	
 	@PostMapping(value = "/aeropuertos/{aeropuertoId}/edit")
-	public String processUpdateVueloForm(@Valid Aeropuerto aeropuerto, BindingResult result, @PathVariable("vueloId") int aeropuertoId) {
+	public String processUpdateAeropuertoForm(@Valid Aeropuerto aeropuerto, BindingResult result, @PathVariable("aeropuertoId") int aeropuertoId) {
 		if(result.hasErrors()) {
 			return VIEWS_AEROPUERTO_CREATE_OR_UPDATE_FORM;
 		}
 		else {
 			aeropuerto.setId(aeropuertoId);
-			this.aeropuertoService.saveAeropuerto(aeropuerto);
+			try {
+				this.aeropuertoService.saveAeropuerto(aeropuerto);
+			} catch (TelefonoErroneoException e) {
+				 result.rejectValue("telefono", "invalid", "invalid phone number");
+				 return VIEWS_AEROPUERTO_CREATE_OR_UPDATE_FORM;
+			}
 			
-			
+		
 			return "redirect:/aeropuertos/{aeropuertoId}";
 		}
 	}
-	
-	
-	
 
 }

--- a/src/main/resources/db/hsqldb/data.sql
+++ b/src/main/resources/db/hsqldb/data.sql
@@ -11,7 +11,7 @@ INSERT INTO authorities(id,username,authority) VALUES (2,'21333214R','azafato');
 
 --Aeropuertos
 INSERT INTO aeropuertos(nombre,localizacion,codigo_IATA,telefono)
-VALUES ('Aeropuerto de São Paulo Guarulhos','São Paulo, Brasil' , 'GRU', '11 2445 2945');
+VALUES ('Aeropuerto de São Paulo Guarulhos','São Paulo, Brasil' , 'GRU', '+551124452945');
 
 INSERT INTO aeropuertos(nombre,localizacion,codigo_IATA,telefono)
 VALUES ('Aeropuerto de Barajas','São Paulo, Sevilla' , 'MAD', '913 21 10 00');

--- a/src/main/webapp/WEB-INF/jsp/aeropuertos/createOrUpdateAeropuertoForm.jsp
+++ b/src/main/webapp/WEB-INF/jsp/aeropuertos/createOrUpdateAeropuertoForm.jsp
@@ -1,0 +1,33 @@
+<%@ page session="false" trimDirectiveWhitespaces="true" %>
+<%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
+<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="form" uri="http://www.springframework.org/tags/form" %>
+<%@ taglib prefix="aerolineasAAAFC" tagdir="/WEB-INF/tags" %>
+
+<aerolineasAAAFC:layout pageName="aeropuertos">
+    <h2>
+        <c:if test="${aeropuerto['new']}">Nuevo </c:if> Aeropuerto
+    </h2>
+    <form:form modelAttribute="aeropuerto" class="form-horizontal" id="add-aeropuerto-form">
+        <div class="form-group has-feedback">
+            <aerolineasAAAFC:inputField label="Nombre del aeropuerto" name="nombre"/>
+            <aerolineasAAAFC:inputField label="Localización" name="localizacion"/>
+            <aerolineasAAAFC:inputField label="Código IATA" name="codigoIATA"/>
+            <aerolineasAAAFC:inputField label="Teléfono" name="telefono"/>
+        </div>
+        <div class="form-group">
+            <div class="col-sm-offset-2 col-sm-10">
+                <c:choose>
+                    <c:when test="${aeropuerto['new']}">
+                        <button class="btn btn-default" type="submit">Añadir aeropuerto</button>
+                    </c:when>
+                    <c:otherwise>
+                        <button class="btn btn-default" type="submit">Actualizar aeropuerto</button>
+                    </c:otherwise>
+                </c:choose>
+            </div>
+        </div>
+    </form:form>
+</aerolineasAAAFC:layout>

--- a/src/test/java/org/springframework/samples/aerolineasAAAFC/service/AeropuertoServiceTests.java
+++ b/src/test/java/org/springframework/samples/aerolineasAAAFC/service/AeropuertoServiceTests.java
@@ -1,0 +1,127 @@
+package org.springframework.samples.aerolineasAAAFC.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collection;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.samples.aerolineasAAAFC.model.Aeropuerto;
+import org.springframework.samples.aerolineasAAAFC.service.exceptions.TelefonoErroneoException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@DataJpaTest(includeFilters = @ComponentScan.Filter(Service.class))
+public class AeropuertoServiceTests {
+
+	@Autowired
+	protected AeropuertoService aeropuertoService;
+	
+	
+	//TEST DE CONSULTA
+	@Test
+	void getNombreAeropuertoSuccessful() {
+		Aeropuerto aero = aeropuertoService.findAeropuertoById(1);
+		assertThat(aero.getNombre())
+		.isNotEmpty()
+		.hasToString("Aeropuerto de São Paulo Guarulhos");
+	}
+	
+	@Test
+	void getLocalizacionAeropuertoSuccessful() {
+		Aeropuerto aero = aeropuertoService.findAeropuertoById(1);
+		assertThat(aero.getLocalizacion())
+		.isNotEmpty()
+		.hasToString("São Paulo, Brasil");
+	}
+	
+	@Test
+	void getCodigoIATAAeropuertoSuccessful() {
+		Aeropuerto aero = aeropuertoService.findAeropuertoById(1);
+		assertThat(aero.getCodigoIATA())
+		.isNotEmpty()
+		.hasToString("GRU");
+	}
+	
+	@Test
+	void getTelefonoAeropuertoSuccessful() {
+		Aeropuerto aero = aeropuertoService.findAeropuertoById(1);
+		assertThat(aero.getTelefono())
+		.isNotEmpty()
+		.containsPattern("^(\\+|\\d)[0-9]{7,16}$");
+	}
+	
+	
+	//TEST DE INSERCIÓN
+	@Test
+	@Transactional
+	public void shouldInsertAeropuerto() {
+		Collection<Aeropuerto> aeros = this.aeropuertoService.findAeropuertos();
+		int found = aeros.size();
+		
+		Aeropuerto aero = new Aeropuerto();
+		aero.setNombre("Aeropuerto Humberto Delgado");
+		aero.setLocalizacion("Lisboa, Portugal");
+		aero.setCodigoIATA("LIS");
+		aero.setTelefono("+351218413500");
+		
+		try {
+			this.aeropuertoService.saveAeropuerto(aero);
+		} catch(TelefonoErroneoException ex) {
+			Logger.getLogger(AeropuertoServiceTests.class.getName()).log(Level.SEVERE, null, ex);
+		}
+		
+		assertThat(aero.getId()).isNotEqualTo(0);
+		
+		aeros = this.aeropuertoService.findAeropuertos();
+		assertThat(aeros.size()).isEqualTo(found + 1);
+	}
+	
+	@Test
+	@Transactional
+	public void shoulNotInsertAeropuertoTelefonoInvalido() {
+		Collection<Aeropuerto> aeros = this.aeropuertoService.findAeropuertos();
+		int found = aeros.size();
+		
+		Aeropuerto aero = new Aeropuerto();
+		aero.setNombre("Aeropuerto de Málaga - Costa del Sol");
+		aero.setLocalizacion("Málaga, España");
+		aero.setCodigoIATA("AGP");
+		aero.setTelefono("12 345 678 910");
+		
+		Assertions.assertThrows(TelefonoErroneoException.class, ()->{ this.aeropuertoService.saveAeropuerto(aero); });
+		aeros = this.aeropuertoService.findAeropuertos();
+		assertThat(aeros.size()).isEqualTo(found);
+	}
+	
+	
+	//TEST DE ACTUALIZACIÓN
+	@Test
+	void shouldUpdateNombreAeropuerto() {
+		Aeropuerto aero = aeropuertoService.findAeropuertoById(1);
+		
+		aero.setNombre("Aeropuerto Internacional de São Paulo Guarulhos");
+		
+		assertThat(aero.getNombre())
+		.isNotEmpty()
+		.isEqualTo("Aeropuerto Internacional de São Paulo Guarulhos");
+	}
+	
+	//TEST DE BORRADO
+	@Test
+	@Transactional
+	public void shouldDeleteAeropuertoById() {
+		Collection<Aeropuerto> aeros = this.aeropuertoService.findAeropuertos();
+		int found = aeros.size();
+		
+		aeropuertoService.eliminarAeropuerto(1);
+		
+		aeros = this.aeropuertoService.findAeropuertos();
+		assertThat(aeros.size()).isEqualTo(found - 1);
+	}
+}

--- a/src/test/java/org/springframework/samples/aerolineasAAAFC/web/AeropuertoControllerTests.java
+++ b/src/test/java/org/springframework/samples/aerolineasAAAFC/web/AeropuertoControllerTests.java
@@ -1,0 +1,118 @@
+package org.springframework.samples.aerolineasAAAFC.web;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.samples.aerolineasAAAFC.configuration.SecurityConfiguration;
+import org.springframework.samples.aerolineasAAAFC.model.Aeropuerto;
+import org.springframework.samples.aerolineasAAAFC.service.AeropuertoService;
+import org.springframework.security.config.annotation.web.WebSecurityConfigurer;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers=AeropuertoController.class,
+excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebSecurityConfigurer.class),
+excludeAutoConfiguration = SecurityConfiguration.class)
+public class AeropuertoControllerTests {
+	
+	private static final int TEST_AERO_ID = 3;
+	
+	@Autowired
+	private AeropuertoController aeropuertoController;
+	
+	@MockBean
+	private AeropuertoService aeropuertoService;
+	
+	@Autowired
+	private MockMvc mockMvc;
+	private Aeropuerto ejemplo;
+	
+	@BeforeEach
+	void setup() {
+		ejemplo = new Aeropuerto();
+		ejemplo.setId(TEST_AERO_ID);
+		ejemplo.setNombre("Aeropuerto Josep Tarradellas Barcelona-El Prat");
+		ejemplo.setLocalizacion("Barcelona, España");
+		ejemplo.setCodigoIATA("BCN");
+		ejemplo.setTelefono("+34913211000");
+		
+		given(this.aeropuertoService.findAeropuertoById(TEST_AERO_ID)).willReturn(ejemplo);
+	}
+	
+	//TEST DE INSERCIÓN
+	@WithMockUser(value = "spring")
+	@Test
+	void testInitCreationForm() throws Exception{
+		mockMvc.perform(get("/aeropuertos/new"))
+		.andExpect(status().isOk())
+		.andExpect(model().attributeExists("aeropuerto"))
+		.andExpect(view().name("aeropuertos/createOrUpdateAeropuertoForm"));
+	}
+	
+	@WithMockUser(value = "spring")
+	@Test
+	void testProcessCreationFormSuccess() throws Exception{
+		mockMvc.perform(post("/aeropuertos/new")
+				.param("nombre", "Aeropuerto de Gran Canaria")
+				.param("localizacion", "Las Palmas, España")
+				.with(csrf())
+				.param("codigoIATA", "LPA")
+				.param("telefono", "+34928579130"))
+		.andExpect(status().is3xxRedirection());
+	}
+	
+	@WithMockUser(value = "spring")
+	@Test
+	void testProcessCreationFormHasErrors() throws Exception{
+		mockMvc.perform(post("/aeropuertos/new")
+				.param("nombre", "Aeropuerto de Gran Canaria")
+				.param("localizacion", "Las Palmas, España")
+				.with(csrf())
+				.param("codigoIATA", "LPA")
+				.param("telefono", "923 238 380"))
+		.andExpect(status().isOk())
+		.andExpect(model().attributeHasErrors("aeropuerto"))
+		.andExpect(model().attributeHasFieldErrors("aeropuerto", "telefono"))
+		.andExpect(view().name("aeropuertos/createOrUpdateAeropuertoForm"));
+	}
+	
+	//TEST DE ACTUALIZACION
+	@WithMockUser(value = "spring")
+	@Test
+	void testProcessUpdateAeropuertoSuccess() throws Exception{
+		mockMvc.perform(post("/aeropuertos/{aeropuertoId}/edit", TEST_AERO_ID)
+				.with(csrf())
+				.param("nombre", "Aeropuerto Internacional Josep Tarradellas Barcelona-El Prat")
+				.param("localizacion", "Barcelona, Cataluña")
+				.param("codigoIATA", "BCN")
+				.param("telefono", "+34913211000"))
+		.andExpect(view().name("redirect:/aeropuertos/{aeropuertoId}"));
+	}
+	
+	@WithMockUser(value = "spring")
+	@Test
+	void testProcessUpdateAeropuertoError() throws Exception{
+		mockMvc.perform(post("/aeropuertos/{aeropuertoId}/edit", TEST_AERO_ID)
+				.with(csrf())
+				.param("nombre", "Aeropuerto Josep Tarradellas Barcelona-El Prat")
+				.param("localizacion", "Barcelona, España")
+				.param("codigoIATA", "BCN")
+				.param("telefono", "123 467 898"))
+		.andExpect(status().isOk())
+		.andExpect(model().attributeHasErrors("aeropuerto"))
+		.andExpect(model().attributeHasFieldErrors("aeropuerto", "telefono"))
+		.andExpect(view().name("aeropuertos/createOrUpdateAeropuertoForm"));
+	}
+}


### PR DESCRIPTION
Creadas las clases de test AeropuertoServiceTests y
AeropuertoControllerTests, corrigiendo errores en el controlador de
Aeropuerto y un cambio en la expresion regular del atributo telefono
para que acepte numeros internacionales (ahora hay que especificar
siempre el prefijo y escribir los numeros sin espacios) y ademas
creacion de una excepcion nueva asociada a los numeros de telefono de
los aeropuertos