### PR TITLE
Cambios en las relaciones entre la tripulación y los vuelos

### DIFF
--- a/src/main/java/org/springframework/samples/aerolineasAAAFC/model/Avion.java
+++ b/src/main/java/org/springframework/samples/aerolineasAAAFC/model/Avion.java
@@ -7,12 +7,9 @@ import java.util.Set;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.ManyToMany;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
-import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Positive;
 import javax.validation.constraints.PositiveOrZero;
 
 import org.hibernate.validator.constraints.Range;
@@ -76,13 +73,5 @@ public class Avion extends BaseEntity{
 	@OneToMany(cascade = CascadeType.ALL, mappedBy="avion") 
 	@EqualsAndHashCode.Exclude
 	private Set<Vuelo> vuelos;
-	
-	@ManyToMany(mappedBy="aviones")
-	@EqualsAndHashCode.Exclude
-	private Set<Azafato> azafatos;
-	
-	@ManyToMany(mappedBy="aviones")
-	@EqualsAndHashCode.Exclude
-	private Set<PersonalControl> personalControl;
 	
 }

--- a/src/main/java/org/springframework/samples/aerolineasAAAFC/model/Azafato.java
+++ b/src/main/java/org/springframework/samples/aerolineasAAAFC/model/Azafato.java
@@ -48,7 +48,7 @@ public class Azafato extends Person{
 
 	@ManyToMany(cascade = CascadeType.ALL)
 	@EqualsAndHashCode.Exclude 
-	private Set<Avion> aviones;
+	private Set<Vuelo> vuelos;
 	
 	public String toString() {
 		

--- a/src/main/java/org/springframework/samples/aerolineasAAAFC/model/PersonalControl.java
+++ b/src/main/java/org/springframework/samples/aerolineasAAAFC/model/PersonalControl.java
@@ -7,15 +7,10 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
-import javax.persistence.JoinColumn;
 import javax.persistence.ManyToMany;
-import javax.persistence.OneToOne;
 import javax.persistence.Table;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
-import javax.validation.constraints.Pattern;
-
-import org.springframework.data.annotation.Id;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -45,6 +40,6 @@ public class PersonalControl extends Person{
 	
 	@ManyToMany(cascade = CascadeType.ALL)
 	@EqualsAndHashCode.Exclude
-	private Set<Avion> aviones;
+	private Set<Vuelo> vuelos;
 
 }

--- a/src/main/java/org/springframework/samples/aerolineasAAAFC/model/Vuelo.java
+++ b/src/main/java/org/springframework/samples/aerolineasAAAFC/model/Vuelo.java
@@ -3,7 +3,6 @@ package org.springframework.samples.aerolineasAAAFC.model;
 import java.time.LocalDateTime;
 import java.util.Set;
 
-import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.JoinColumn;
@@ -71,6 +70,14 @@ public class Vuelo extends BaseEntity{
 	@EqualsAndHashCode.Exclude
 	@JoinColumn(name = "avion_id")
 	private Avion avion;
+	
+	@ManyToMany(mappedBy="vuelos")
+	@EqualsAndHashCode.Exclude
+	private Set<Azafato> azafatos;
+	
+	@ManyToMany(mappedBy="vuelos")
+	@EqualsAndHashCode.Exclude
+	private Set<PersonalControl> personalControl;
 
 	
 }

--- a/src/main/webapp/WEB-INF/jsp/aviones/avionDetails.jsp
+++ b/src/main/webapp/WEB-INF/jsp/aviones/avionDetails.jsp
@@ -80,7 +80,7 @@ edición y borrado en una vista u otra -->
     <br/>
     <br/>
     <br/>
-    <h2>Vuelos y personal</h2>
+    <h2>Vuelos asociados</h2>
 <!--
     <table class="table table-striped">
         <c:forEach var="pet" items="${owner.pets}">

--- a/src/main/webapp/WEB-INF/jsp/aviones/avionesList.jsp
+++ b/src/main/webapp/WEB-INF/jsp/aviones/avionesList.jsp
@@ -16,15 +16,10 @@ puede acceder a la ficha de cada avión (por id) para editarlo o borrarlo -->
         <tr>
             <th>ID Avión</th>
             <th>Tipo de avión</th>
-            <th>Capacidad de pasajeros</th>
-            <th>Peso máximo de equipaje</th>
             <th>Horas de vuelo acumuladas</th>
             <th>Fecha de fabricación</th>
-            <th>Disponibilidad</th>
             <th>Última revisión</th>
-            <th>Plazas clase económica</th>
-            <th>Plazas clase ejecutiva</th>
-            <th>Plazas primera clase</th>
+            <th>Disponibilidad</th>
             <th> </th>
         </tr>
         </thead>
@@ -41,16 +36,13 @@ puede acceder a la ficha de cada avión (por id) para editarlo o borrarlo -->
                     <c:out value="${avion.tipoAvion}"/>
                 </td>
                 <td>
-                    <c:out value="${avion.capacidadPasajero}"/>
-                </td>
-                <td>
-                    <c:out value="${avion.pesoMaximoEquipaje}"/>
-                </td>
-                <td>
                     <c:out value="${avion.horasAcumuladas}"/>
                 </td>
                 <td>
                     <c:out value="${avion.fechaFabricacion}"/>
+                </td>
+                <td>
+                    <c:out value="${avion.fechaRevision}"/>
                 </td>
                 <td>
                     <c:choose>
@@ -63,18 +55,6 @@ puede acceder a la ficha de cada avión (por id) para editarlo o borrarlo -->
         					<br />
     					</c:otherwise>
 					</c:choose>
-                </td>
-                <td>
-                    <c:out value="${avion.fechaRevision}"/>
-                </td>
-                <td>
-                    <c:out value="${avion.plazasEconomica}"/>
-                </td>
-                <td>
-                    <c:out value="${avion.plazasEjecutiva}"/>
-                </td>
-                <td>
-                    <c:out value="${avion.plazasPrimera}"/>
                 </td>
                 <td>
                 	<spring:url value="/aviones/{avionId}/edit" var="avionUrl">

--- a/src/test/java/org/springframework/samples/aerolineasAAAFC/service/AvionServiceTests.java
+++ b/src/test/java/org/springframework/samples/aerolineasAAAFC/service/AvionServiceTests.java
@@ -109,15 +109,15 @@ public class AvionServiceTests {
 		assertThat(avion.getCapacidadPasajero()).isEqualTo(100);
 	}
 
-	@Test
-	@Transactional
-	void updateAzafatosAvionSuccessful() {
-		Avion avion=avionService.findAvionById(1);
-		Set<Azafato> azafatos=new HashSet<>();
-		//azafatos.add(e);
-		avion.setAzafatos(azafatos);
-		assertThat(avion.getAzafatos()).isEqualTo(azafatos);
-	}
+//	@Test
+//	@Transactional
+//	void updateAzafatosAvionSuccessful() {
+//		Avion avion=avionService.findAvionById(1);
+//		Set<Azafato> azafatos=new HashSet<>();
+//		//azafatos.add(e);
+//		avion.setAzafatos(azafatos);
+//		assertThat(avion.getAzafatos()).isEqualTo(azafatos);
+//	}
 
 	@Test
 	@Transactional
@@ -154,15 +154,15 @@ public class AvionServiceTests {
 		assertThat(avion.getHorasAcumuladas()).isEqualTo(140);
 	}
 	
-	@Test
-	@Transactional
-	void updatePersonalControlAvionSuccessful() {
-		Avion avion=avionService.findAvionById(1);
-		Set<PersonalControl> personal= new HashSet<>();
-		//personal.add();
-		avion.setPersonalControl(personal);
-		assertThat(avion.getPersonalControl()).isEqualTo(personal);
-	}
+//	@Test
+//	@Transactional
+//	void updatePersonalControlAvionSuccessful() {
+//		Avion avion=avionService.findAvionById(1);
+//		Set<PersonalControl> personal= new HashSet<>();
+//		//personal.add();
+//		avion.setPersonalControl(personal);
+//		assertThat(avion.getPersonalControl()).isEqualTo(personal);
+//	}
 
 	@Test
 	@Transactional
@@ -205,17 +205,17 @@ public class AvionServiceTests {
 		Collection<Avion> aviones = this.avionService.findAviones();
 		int found = aviones.size();
 		
-		Azafato aza = this.azafatoService.findAzafatoById(1);
-		Set<Azafato> azas = new HashSet<Azafato>();
-		azas.add(aza);
+//		Azafato aza = this.azafatoService.findAzafatoById(1);
+//		Set<Azafato> azas = new HashSet<Azafato>();
+//		azas.add(aza);
 		
 		Vuelo vue = this.vueloService.findVueloById(1);
 		Set<Vuelo> vues = new HashSet<Vuelo>();
 		vues.add(vue);
 		
-		PersonalControl pCon = this.pControlService.findPersonalControlById(1);
-		Set<PersonalControl> pCons = new HashSet<PersonalControl>();
-		pCons.add(pCon);
+//		PersonalControl pCon = this.pControlService.findPersonalControlById(1);
+//		Set<PersonalControl> pCons = new HashSet<PersonalControl>();
+//		pCons.add(pCon);
 		
 		
 		Avion avi = new Avion();
@@ -230,9 +230,9 @@ public class AvionServiceTests {
 		avi.setPlazasEjecutiva(40);
 		avi.setPlazasPrimera(20);
 		
-		avi.setAzafatos(azas);
+//		avi.setAzafatos(azas);
 		avi.setVuelos(vues);
-		avi.setPersonalControl(pCons);
+//		avi.setPersonalControl(pCons);
 		
 		// Por ahora no hay restricciones que puedan saltar por insercion de datos
 		this.avionService.saveAvion(avi);

--- a/src/test/java/org/springframework/samples/aerolineasAAAFC/web/AvionControllerTests.java
+++ b/src/test/java/org/springframework/samples/aerolineasAAAFC/web/AvionControllerTests.java
@@ -57,7 +57,7 @@ public class AvionControllerTests {
 	void setup() {
 		apache =new Avion();
 		apache.setId(TEST_AVION_ID);
-		apache.setAzafatos(new HashSet<>());
+//		apache.setAzafatos(new HashSet<>());
 		apache.setCapacidadPasajero(100);
 		
 		apache.setDisponibilidad(false);
@@ -65,7 +65,7 @@ public class AvionControllerTests {
 		apache.setFechaFabricacion(LocalDate.of(2015, 12, 8));
 	
 		apache.setHorasAcumuladas(12);
-		apache.setPersonalControl(new HashSet<>());
+//		apache.setPersonalControl(new HashSet<>());
 		apache.setPesoMaximoEquipaje(21);
 		apache.setPlazasEconomica(3);
 		apache.setPlazasEjecutiva(3);


### PR DESCRIPTION
Ahora PersonalControl y Azafato pasan a estar relacionados con Vuelo en
lugar de con Avion. He comentado también los tests de Avion en los que
se tenían en cuenta los azafatos y pilotos. Por último he corregido la
vista de avionesList, a falta de terminar la de detalle.