### PR TITLE
Corregido el tema de la vista de estadoAviones (HU 4)

### DIFF
--- a/src/main/java/org/springframework/samples/aerolineasAAAFC/web/AvionController.java
+++ b/src/main/java/org/springframework/samples/aerolineasAAAFC/web/AvionController.java
@@ -137,7 +137,7 @@ public class AvionController {
 		return mav;
 	}
 	
-	@GetMapping(value = "/aviones/rutaAviones")
+	@GetMapping(value = "/aviones/estadoAviones")
 	public String showAvionesListPersonal(Map<String, Object> model, @PageableDefault(value=20) Pageable paging) {
 		
 		Page<Avion> pages = avionService.findAviones(paging);
@@ -147,7 +147,7 @@ public class AvionController {
 		model.put("size", pages.getSize());
 		model.put("aviones",pages.getContent());
 
-		return "aviones/rutaAviones";
+		return "aviones/estadoAviones";
 	}
 	
 	

--- a/src/main/webapp/WEB-INF/jsp/aviones/avionesList.jsp
+++ b/src/main/webapp/WEB-INF/jsp/aviones/avionesList.jsp
@@ -71,6 +71,10 @@ puede acceder a la ficha de cada avión (por id) para editarlo o borrarlo -->
 					<td></td><td></td><td></td><td></td><td></td><td></td>
 					<td><a href="<spring:url value="/aviones/new" htmlEscape="true"/>"class="btn btn-default">Nuevo Avión</a></td>
 				</tr>
+				<tr>
+					<td></td><td></td><td></td><td></td><td></td><td></td>
+					<td><a href="<spring:url value="/aviones/estadoAviones" htmlEscape="true"/>"class="btn btn-default centrado">Ver estado aviones</a></td>
+				</tr>
 			</sec:authorize>
 		</tbody>
     </table>

--- a/src/main/webapp/WEB-INF/jsp/aviones/estadoAviones.jsp
+++ b/src/main/webapp/WEB-INF/jsp/aviones/estadoAviones.jsp
@@ -7,9 +7,6 @@
 <%@ taglib prefix="sec"
 	uri="http://www.springframework.org/security/tags"%>
 
-<!-- Archivo .jsp que muestra el listado de todos los aviones, a su vez se
-puede acceder a la ficha de cada avión (por id) para editarlo o borrarlo -->
-
 <aerolineasAAAFC:layout pageName="aviones">
     <h2 class="centrado">Estado de aviones</h2>
 

--- a/src/test/java/org/springframework/samples/aerolineasAAAFC/web/AvionControllerTests.java
+++ b/src/test/java/org/springframework/samples/aerolineasAAAFC/web/AvionControllerTests.java
@@ -211,5 +211,13 @@ public class AvionControllerTests {
 		.andExpect(model().attributeExists("aviones"))
 		.andExpect(view().name("aviones/avionesList"));
 	}
+	
+	@WithMockUser(value = "spring")
+	@Test
+	void testShowEstadoAviones() throws Exception {
+		mockMvc.perform(get("/aviones/estadoAviones"))
+		.andExpect(model().attributeExists("aviones"))
+		.andExpect(view().name("aviones/estadoAviones"));
+	}
 
 }


### PR DESCRIPTION
He cambiado el nombre de la vista y la ruta del controlador de
rutaAviones a estadoAviones, añadido su test en AvionControllerTests y
añadido el botón de acceso en la vista de avionesList, siendo solamente
accesible para el personal de oficina y para el admin.